### PR TITLE
add powerup approach to gzip changing of RunVaspCustodian

### DIFF
--- a/atomate/vasp/powerups.py
+++ b/atomate/vasp/powerups.py
@@ -568,3 +568,16 @@ def use_gamma_vasp(original_wf, gamma_vasp_cmd):
     for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint="RunVaspCustodian"):
         original_wf.fws[idx_fw].tasks[idx_t]["gamma_vasp_cmd"] = gamma_vasp_cmd
     return original_wf
+
+def modify_gzip_vasp(original_wf, gzip_output):
+    """
+    For all RunVaspCustodian tasks, modify gzip_output boolean
+    Args:
+        original_wf (Workflow)
+        gzip_output (bool): Value to set gzip_output to for RunVaspCustodian
+    Returns:
+       Workflow
+    """
+    for idx_fw, idx_t in get_fws_and_tasks(original_wf, task_name_constraint="RunVaspCustodian"):
+        original_wf.fws[idx_fw].tasks[idx_t]["gzip_output"] = gzip_output
+    return original_wf

--- a/atomate/vasp/workflows/base/ferroelectric.py
+++ b/atomate/vasp/workflows/base/ferroelectric.py
@@ -16,7 +16,7 @@ from atomate.vasp.fireworks.core import OptimizeFW
 from atomate.vasp.fireworks.polarization import LcalcpolFW
 from atomate.vasp.fireworks.core import HSEBSFW
 from atomate.vasp.firetasks.parse_outputs import PolarizationToDb
-from atomate.vasp.powerups import add_tags
+from atomate.vasp.powerups import add_tags, modify_gzip_vasp
 
 __author__ = 'Tess Smidt'
 __email__ = 'tsmidt@berkeley.edu'
@@ -139,5 +139,8 @@ def get_wf_ferroelectric(polar_structure, nonpolar_structure, vasp_cmd="vasp", d
     # Create Workflow task and add tags to workflow
     workflow = Workflow(wf)
     workflow = add_tags(workflow, [wfid] + tags)
+
+    # Prevent gzipping from RunVaspCustodian approaches
+    workflow = modify_gzip_vasp(workflow, False)
 
     return workflow


### PR DESCRIPTION
Simple power-up added for turning gzip off for all RunVaspCustodians in a workflow. This is a necessary requirement for using the get_wf_ferroelectric workflow.